### PR TITLE
Allow usage of array data from previous responses in Value()

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -137,7 +137,28 @@ export const computeRequestObject = (obj: Object, r: any) => {
           const innerMatchValue = m.match(innerReg);
           if(innerMatchValue !== null) {
             try {
-              const index = (obj: any ,i:any) => obj[i]
+              const index = (obj:any, i:any) => {
+                const arrIndexReg = /\[(.*?)\]/gm;
+                const arrNameReg = /^[^\[]*/gm;
+                let m;
+                const arrIndices = [];
+
+                do {
+                  m = arrIndexReg.exec(i);
+                  if (m !== null) {
+                    arrIndices.push(parseInt(m[1]));
+                  }
+                } while(m !== null);
+
+                if (arrIndices.length) {
+                  const name = i.match(arrNameReg)[0];
+                  console.log(name);
+                  return arrIndices.reduce((agg:any, i:any) => agg[i], obj[name]);
+                }
+
+                return obj[i];
+              }
+
               let reducedValue = innerMatchValue[1].split('.').reduce(index, r)
               if(typeof reducedValue !== 'undefined') {
                 // replace the string with the new value


### PR DESCRIPTION
I found that I had a use case where I needed to take an id from an object that was part of an array in a response and use that id to test the next endpoint.

```json
datalist: [
    {
       "id": "someId",
       "data": "some data"
    }
]
```
I then wanted to be able to do this inside the next request:
```yml
data:
   json:
      id: Value(myPreviousRequest.datalist[0].id)
```

This PR implements that functionality and allows for arbitrary nesting of arrays.