### PR TITLE
Add validation for response codes

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -13,6 +13,7 @@ const dataSchema = Joi.object().keys({
   .without('raw', 'formUrlEncoded')
 
 const validateSchema = Joi.object().keys({
+  code: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
   json: Joi.object().optional(),
   raw: Joi.string().optional()
 })

--- a/src/test.ts
+++ b/src/test.ts
@@ -337,6 +337,22 @@ const validateResponse = (validateSchema: any, dataToProof: any) => {
    *  token: Type(string | null)
    */
   let proofObject: any = validateSchema.json || validateSchema.raw;
+  let codeProofValue: any = validateSchema.code;
+  if (codeProofValue) {
+    if (!dataToProof.code) {
+      return validationError(`The key ${chalk.bold('code')} was defined in the validation schema but there the response did not contain a valid status code.`)
+    }
+
+    const codeChars = codeProofValue.toString().split('');
+    const dataChars = dataToProof.code.toString().split('');
+    for (let i = 0; i < codeChars.length; i++) {
+      const ch = codeChars[i];
+      const dataCh = dataChars[i];
+      if (ch !== 'x' && dataCh !== ch) {
+        return validationError(`The response status code should be ${chalk.bold(codeProofValue)} but the request returned code ${chalk.bold(dataToProof.code)}`);
+      }
+    }
+  }
 
   if(typeof proofObject === 'object') {
     for(let key in proofObject) {
@@ -426,6 +442,7 @@ const performRequest = async (requestObject: requestObjectSchema, requestName: s
 
     if(typeof requestObject.validate !== 'undefined') {
      
+      response.data.code = response.status;
       const err = validateResponse(requestObject.validate, response.data);
 
       if(err !== null) {


### PR DESCRIPTION
Implements #34 

This is a basic `code: 2xx` type of validation, which I think is a good start. However, I do think the discussion on #6 is interesting too. Implementing something with flexibility to allow things like `code: Code(200-399)` `code: Code(2xx)` or `code: Code(200 | 201)` would be really cool.

What are your thoughts? Is it worth tackling the more flexible form?