### PR TITLE
Add ability to validate response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ requests:
           iconUrl: Type(String.Url)
         someOtherData: "match this string" 
 ```
+#### Header Validation
+```yaml
+requests:
+  example:
+    ...
+    validate:
+      headers:
+        content-type: application/json; charset=utf-8
+        access-control-allow-credentials: Type(Boolean | String)
+```
 ## Errors
 **Strest** is a testing library so of course, you'll run into a few errors when testing an endpoint. Error handling is made very simple so can instantly see what caused an error and fix it.
 If a request fails, the process will be exited with _exit code 1_ and no other requests will be executed afterwards.

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -14,6 +14,7 @@ const dataSchema = Joi.object().keys({
 
 const validateSchema = Joi.object().keys({
   code: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
+  headers: Joi.object().optional(),
   json: Joi.object().optional(),
   raw: Joi.string().optional()
 })

--- a/src/test.ts
+++ b/src/test.ts
@@ -361,6 +361,7 @@ const validateResponse = (validateSchema: any, dataToProof: any) => {
    *  token: Type(string | null)
    */
   let proofObject: any = validateSchema.json || validateSchema.raw;
+  let headersProofObject: any = validateSchema.headers;
   let codeProofValue: any = validateSchema.code;
   if (codeProofValue) {
     if (!dataToProof.code) {
@@ -381,6 +382,14 @@ const validateResponse = (validateSchema: any, dataToProof: any) => {
   if(typeof proofObject === 'object') {
     for(let key in proofObject) {
       let err = createValidationLoop(proofObject, dataToProof, key)
+      if(err !== null) {
+        return err;
+      }
+    }
+  }
+  if(typeof headersProofObject === 'object') {
+    for(let key in headersProofObject) {
+      let err = createValidationLoop(headersProofObject, dataToProof.headers, key)
       if(err !== null) {
         return err;
       }
@@ -467,6 +476,7 @@ const performRequest = async (requestObject: requestObjectSchema, requestName: s
     if(typeof requestObject.validate !== 'undefined') {
      
       response.data.code = response.status;
+      response.data.headers = response.headers;
       const err = validateResponse(requestObject.validate, response.data);
 
       if(err !== null) {

--- a/tests/success/headers.strest.yml
+++ b/tests/success/headers.strest.yml
@@ -1,0 +1,10 @@
+version: 1
+
+requests:
+  headersValidate:
+    url: https://jsonplaceholder.typicode.com/todos
+    method: GET
+    validate:
+      headers:
+        content-type: application/json; charset=utf-8
+        access-control-allow-credentials: Type(Boolean | String)


### PR DESCRIPTION
#33 

Uses existing infrastructure to do the validation trigger a recursive check down through the response headers.