### PR TITLE
Add feature to continue even after a failed response code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strest-cli",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A new dimension of REST API testing",
   "main": "dist/main.js",
   "repository": "https://github.com/eykhagen/strest",

--- a/tests/failure/failureRequest1.strest.yaml
+++ b/tests/failure/failureRequest1.strest.yaml
@@ -4,3 +4,5 @@ requests:
   notFound:
     url: https://jsonplaceholder.typicode.com/test/
     method: GET
+    validate:
+      code: 2xx


### PR DESCRIPTION
Before this patch, the test failed when a request returned a bad code (any code except 2xx), even when you enabled response-code-validation.

Now you can insert a validation-code e.g. 404 and when the request returned an 404 error, the test will move on to the next request instead of exiting.