### PR TITLE
moved faker and jsonpath types from Dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "test": "strest tests/success"
   },
   "dependencies": {
-    "@types/faker": "^4.1.3",
-    "@types/jsonpath": "^0.2.0",
     "axios": "^0.18.0",
     "chalk": "^2.4.1",
     "commander": "^2.17.1",
@@ -46,6 +44,8 @@
     ]
   },
   "devDependencies": {
+    "@types/faker": "^4.1.3",
+    "@types/jsonpath": "^0.2.0",
     "@types/commander": "^2.12.2",
     "@types/jest": "^23.3.2",
     "@types/joi": "^13.4.4",


### PR DESCRIPTION
Hi, only moved 
@types/faker": "^4.1.3",
"@types/jsonpath": "^0.2.0",
to 
devDependencies
as they don't really needed as a dependency in runtime.