### PR TITLE
Issue 95 -add support for filename as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,28 @@ requests:
     url: https://jsonplaceholder.typicode.com/todos/2
     method: GET
 ```
+## Use strest file name as paramter in the tests
+You can use the strest file name as a parmater in the tests .
+
+*note* that the strest suffix is removed 
+
+**Usage**
+The file name for this example is postman-echo.strest.yml
+
+```yml
+version: 1                            # only version at the moment
+
+requests:                             # all test requests will be listed here
+  testRequest:                        # name the request however you want
+    url: https://Filename().com/get  # required
+    method: GET                       # required
+    data:
+      params:
+        name: Salvador Salva Martín
+    validate:
+      code: 200
+
+```
 
 ## Response Validation
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -54,7 +54,8 @@ export const Schema = Joi.object({
   version: Joi.number().min(1).max(1),
   requests: Joi.object({}).pattern(/([^\s]+)/, requestsSchema),
   allowInsecure: Joi.boolean().optional(),
-  variables: Joi.object().optional()
+  variables: Joi.object().optional(),
+  fileName: Joi.string().required()
 });
 
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -55,7 +55,6 @@ export const start = async (dir:string , cmd: any) => {
     console.log();
     return 1;
   }
-  console.log();
   const responseCode = await test.performTests(validTests, cmd) as Number;
   return responseCode;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -55,6 +55,7 @@ export const start = async (dir:string , cmd: any) => {
     console.log();
     return 1;
   }
+  console.log();
   const responseCode = await test.performTests(validTests, cmd) as Number;
   return responseCode;
 }

--- a/src/yaml-parse.ts
+++ b/src/yaml-parse.ts
@@ -18,10 +18,12 @@ export const parseTestingFiles = (pathArray: string[], dir: string) => {
       if(typeof filePath === 'string'){
         const data = fs.readFileSync(filePath.toString(), 'utf8');
         const parsed: any = yaml.safeLoad(data)
+        const {name:fileName} = path.parse(filePath);
         const removeFilename = filePath.substring(0, filePath.lastIndexOf("/") + 1);
         if(dir === null){
           dir = "";
         }
+        parsed.fileName = fileName;
         parsed.relativePath = removeFilename.replace(path.join(process.cwd(), dir), "./")
         responseData.push(parsed);
       }

--- a/tests/success/File/postman-echo.strest.yml
+++ b/tests/success/File/postman-echo.strest.yml
@@ -1,0 +1,11 @@
+version: 1                            # only version at the moment
+
+requests:                             # all test requests will be listed here
+  testFilename:                        # name the request however you want
+    url: https://Filename().com/get  # required
+    method: GET                       # required
+    data:
+      params:
+        name: Salvador Salva Martín
+    validate:
+      code: 200


### PR DESCRIPTION
Hi this PR solvee Issue #95 , Add support for using the strest test filename as a parameter in the request .
I was a little bit  more complicated than stated in the issue , due to the fact that the testObject.relativepath is not the file name , it's just the path to the file . 
1.I have added fileName property on parse file object at yaml-parse.ts, and updated the schema . 
2.Passes the file name to the computeRequestObject that uses the common practice of regex replacing the Filname() string with the fileName 
3.updated the readme 
**I have 2 Notes** 
1.I am removing the strest suffix from the file name - see the  computeRequestObject function .
2.we need to consider using nodejs [path.parse(filePath)](https://nodejs.org/api/path.html#path_path_parse_path)
to get all the file parts .. (folder / root ) 

see this line 
const {name:fileName} = path.parse(filePath);

