### PR TITLE
Issue 95 -add support for filename as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,26 @@ requests:
       method: GET
 ```
 
+## Use strest file name as paramter in the tests
+You can use the strest file name as a parmater in the tests .
+
+*note* that the strest suffix is removed 
+
+**Usage**
+The file name for this example is postman-echo.strest.yml
+
+```yml
+version: 2                            
+requests:                             
+  test-file-name:                       
+    request:
+      url: https://<$ Filename() $>.com/get  
+      method: GET                       
+    validate:
+    - jsonpath: status
+      expect: 200
+```
+
 ## Response Validation
 
 The immediate response is stored in [HAR Format](http://www.softwareishard.com/blog/har-12-spec/#response)

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -107,6 +107,7 @@ export const Schema = Joi.object({
   // Created dynamically
   raw: Joi.string().required(),
   relativePath: Joi.string().required(),
+  fileName: Joi.string().required(),
 });
 
 export const BulkSchema = Joi.array().items(Joi.string());

--- a/src/test.ts
+++ b/src/test.ts
@@ -137,7 +137,7 @@ export const performTests = async (testObjects: object[], cmd: any) => {
             let keys = Object.keys(requests);
             let nextIndex = keys.indexOf(requestName) +1;
             let nextRequest = keys[nextIndex];
-            let computed = computeRequestObject(requestReponsesObj, testObject.raw, requestName, nextRequest);
+            let computed = computeRequestObject(requestReponsesObj, testObject.raw, requestName, nextRequest, testObject.fileName);
             if (computed.error) {
               error = { isError: true, message: computed.message, har: null, code: 0 }
             }
@@ -244,11 +244,13 @@ export const performTests = async (testObjects: object[], cmd: any) => {
  * Use nunjucks to replace and update the object
  * @param obj working obj
  */
-export const computeRequestObject = (r: any, raw: string, requestName: string, nextRequest: string) => {
-
-  let merged = { ...r, ...definedVariables };
+export const computeRequestObject = (r: any, raw: string, requestName: string, nextRequest: string, fileName: string) => {
+  let merged = { ...r, ...definedVariables};
   nunjucksEnv.addGlobal('JsonPath', function (path: string) {
     return jp.value(merged, path)
+  })
+  nunjucksEnv.addGlobal('Filename', function () {
+    return fileName ? fileName.replace('.strest','') : '';
   })
   // Parse obj using nunjucks
   try {

--- a/src/yaml-parse.ts
+++ b/src/yaml-parse.ts
@@ -18,11 +18,13 @@ export const parseTestingFiles = (pathArray: string[], dir: string) => {
       if(typeof filePath === 'string') {
         const data = fs.readFileSync(filePath.toString(), 'utf8');
         const parsed: any = yaml.safeLoad(data);
+        const { name:fileName } = path.parse(filePath);
         const removeFilename = path.dirname(filePath) + path.sep;
         if(dir === null) {
           dir = '';
         }
         parsed.raw = data.replace(/(\rn|\n|\r)/g, '\n')
+        parsed.fileName = fileName;
         parsed.relativePath = removeFilename.replace(path.join(process.cwd(), dir), '.' + path.sep);
         responseData.push(parsed);
       }

--- a/tests/success/file/postman-echo.com.strest.yml
+++ b/tests/success/file/postman-echo.com.strest.yml
@@ -1,0 +1,10 @@
+version: 2                            # only version at the moment
+requests:                             # all test requests will be listed here
+  test-file-name:                       # name the request however you want
+    request:
+      url: https://<$ Filename() $>/get  # required
+      method: GET                       # required
+    # log: true
+    validate:
+    - jsonpath: status
+      expect: 200

--- a/tests/success/file/postman-echo.strest.yml
+++ b/tests/success/file/postman-echo.strest.yml
@@ -1,0 +1,10 @@
+version: 2                            # only version at the moment
+requests:                             # all test requests will be listed here
+  test-file-name-1:                       # name the request however you want
+    request:
+      url: https://<$ Filename() $>.com/get  # required
+      method: GET                       # required
+    # log: true
+    validate:
+    - jsonpath: status
+      expect: 200


### PR DESCRIPTION
Hi this PR solves Issue #95 , Add support for using the strest test filename as a parameter in the request .
I was a little bit more complicated than stated in the issue , due to the fact that the testObject.relativepath is not the file name , it's just the path to the file .
1.I have added fileName property on parse file object at yaml-parse.ts, and updated the schema .
2.Passes the file name to the computeRequestObject that uses the common practice of nunjucksEnv addGlobal to replace the Filname() string with the fileName
3.updated the readme
I have 2 Notes
1.I am removing the strest suffix from the file name - see the computeRequestObject function .
2.we need to consider using nodejs path.parse(filePath)
to get all the file parts .. (folder / root )

see this line in yaml-parse.ts
const {name:fileName} = path.parse(filePath);