### PR TITLE
Added backward support for params in post data

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -15,6 +15,7 @@
             - [`postData`](#postdata)
                 - [`mimeType`](#mimetype)
                 - [`text`](#text)
+                - [`params`](#params)
             - [`queryString`](#querystring)
             - [`headers`](#headers)
         - [`auth`](#auth)

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -137,10 +137,14 @@ interface cookiesObjectSchema {
   name: string,
   value: string,
 }
+interface paramsObjectSchema {
+  name: string,
+  value: string,
+}
 
 interface postDataObjectSchema {
   mimeType: string,
-  params: object,
+  params: Array<paramsObjectSchema>,
   text : string,
   comment: string,
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -405,6 +405,11 @@ const performRequest = async (requestObject: requestsObjectSchema, requestName: 
     if (requestObject.request.postData.text) {
       axiosObject.data = requestObject.request.postData.text;
     }
+    if (requestObject.request.postData.params) {
+      const searchParams = new URLSearchParams()
+      requestObject.request.postData.params.forEach(item=>{searchParams.append(item.name,item.value)})
+      axiosObject.data = searchParams.toString();
+    }
   }
 
   try {

--- a/tests/success/params/post.strest.yml
+++ b/tests/success/params/post.strest.yml
@@ -1,0 +1,19 @@
+version: 2
+
+requests:
+  postwithparams:
+    request:
+      url: https://postman-echo.com/post
+      method: POST
+      postData:
+        mimeType: application/x-www-form-urlencoded
+        params:
+          - name: title
+            value: foo
+          - name: body
+            value: bar
+          - name: userId
+            value: "1"
+    validate:
+      - jsonpath: content.json.title
+        expect: foo


### PR DESCRIPTION
Added backward support for params in post data
this will send post data as simple form data params 
[See Postman echo](https://docs.postman-echo.com/#083e46e7-53ea-87b1-8104-f8917ce58a17)

```
curl --location --request POST "https://postman-echo.com/post" \
  --data "foo1=bar1&foo2=bar2"
```

